### PR TITLE
FC-1179, FC-661 Updates for signQuery and signRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,17 @@ fetch(fullURI, fetchOpts)
 
 signRequest returns an object containing the keys: header, method and body. This object can be used to sign requests that are not related to transactions or queries.
 
-```javascript
+#### Example: Delete Ledger
+The following example demonstrates how to sign a request to delete a ledger.
 
+```javascript
 import { generateKeyPair, getSinFromPublicKey, signRequest } from '@fluree/crypto-utils';
 
 const { publicKey, privateKey }  = generateKeyPair();
 const authId = getSinFromPublicKey(publicKey);
 
+// The host portion of the URL is required as the signRequest 
+// function parses the entire url to build the signing string.
 var endpoint = 'http://localhost:8090/fdb/delete-db';
 
 var body = JSON.stringify({
@@ -127,3 +131,37 @@ var fetchOpts = signRequest("POST", endpoint, body, privateKey, authId);
 fetch(endpoint, fetchOpts)
 ```
 
+#### Example: Transact (Closed-API)
+The following example demonstrates how to submit a transaction, with a valid permissioned auth, that requests the ledger/network to 'sign' the actual transaction since a private key should not be passed in clear-text.  This may be useful in a closed-api environment when the entire output from the transact operation (e.g., temp-ids) is required.
+
+```javascript
+import { signRequest } from '@fluree/crypto-utils';
+
+const auth = "insert your auth here";
+const private = "insert your private key here";
+
+const db = 'test/one'; 
+
+// The host portion of the URL is required as the signRequest 
+// function parses the entire url to build the signing string.
+const endpoint = this.state.dbserverUrl + `/fdb/${db}/transact`;
+
+// substitute your transaction here
+var body = JSON.stringify([{"_id":"_user","username":"newUser"}]);
+
+var options = signRequest("POST", endpoint, body, private, auth);
+
+// Adding a header to set timeout option for transact.
+// This is the amount a time that the request will be monitored
+// for a response from the ledger server(s) before returning a  
+// "408" timeout message. The default timeout period is currently
+// 5 minutes.  
+let rqstOpts = {
+  method: options.method,
+  headers: Object.assign({}, options.headers, {"Request-Timeout": 600000}),
+  body: options.body
+};
+
+fetch(endpoint, rqstOpts)
+:
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ npm install @fluree/crypto-utils
 
 >This library has a dependency on the @fluree/crypto-base library, which can be downloaded via `npm install @fluree/crypto-base`
 
+## Breaking change between version 1.8 & 1.9
+The `host` parameter has been dropped from the signQuery function since it is no longer used to create the signing string.
+
 ## API
 
 ### Generate Keys
@@ -92,11 +95,10 @@ const authId = getSinFromPublicKey(publicKey);
 
 const param = JSON.stringify({select: ["*"], from: "_collection"});
 const db = "test/one";
-const host = "localhost";
 const queryType = "query";
 
 
-const fetchOpts = signQuery(privateKey, param, queryType, host, db)
+const fetchOpts = signQuery(privateKey, param, queryType, db)
 
 const fullURI = `https://localhost:8090/fdb/${db}/query`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fluree/crypto-utils",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fluree/crypto-utils",
-      "version": "1.7.0",
+      "version": "1.9.0",
       "license": "ISC",
       "dependencies": {
         "@fluree/crypto-base": "^0.1.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluree/crypto-utils",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Helper cryptography functions for Fluree",
   "main": "src/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -74,8 +74,8 @@ function signCommand(msg, privateKey){
 }
 
 /**
- * signQuery returns an object that can be used to sign a query.
- * The POST method is assumed to generate the signing string.
+ * signTransaction returns an object that can be used to sign a transaction
+ * targeted for the `command` endpoint.
  *
  * @param {string} auth - auth used to submit the request
  * @param {string} db - the complete name of the ledger (e.g., test/one)

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ function signCommand(msg, privateKey){
  * @param {string} auth - auth used to submit the request
  * @param {string} db - the complete name of the ledger (e.g., test/one)
  * @param {number} expire - the time in seconds before a pending transaction should not be executed. Can be null.
- * @param {numner} fuel - the maximum amount of allowable fuel when executing a transaction. Can be null.
+ * @param {number} fuel - the maximum amount of allowable fuel when executing a transaction. Can be null.
  * @param {number} nonce - any long/64-bit integer value that will make this transaction unique. Can be null.
  * @param {string} privateKey - private key used to create the signed request
  * @param {string} tx - JSON stringified query

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ function signRequest( method, url, body, privateKey, auth ){
   var formattedDate = getRFC1123DateTime();
   var digest = crypto.sha2_256_normalize(body, "base64");
   
-  var signingString = "(request-target): post " + uriParts[4] + 
+  var signingString = "(request-target): post /" + uriParts[4] + 
     "\nx-fluree-date: " + formattedDate + 
     "\ndigest: SHA-256=" + digest;
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,19 @@ function signCommand(msg, privateKey){
    return crypto.sign_message(msg, privateKey);
 }
 
+/**
+ * signQuery returns an object that can be used to sign a query.
+ * The POST method is assumed to generate the signing string.
+ *
+ * @param {string} auth - auth used to submit the request
+ * @param {string} db - the complete name of the ledger (e.g., test/one)
+ * @param {number} expire - the time in seconds before a pending transaction should not be executed. Can be null.
+ * @param {numner} fuel - the maximum amount of allowable fuel when executing a transaction. Can be null.
+ * @param {number} nonce - any long/64-bit integer value that will make this transaction unique. Can be null.
+ * @param {string} privateKey - private key used to create the signed request
+ * @param {string} tx - JSON stringified query
+ * @param {array}  deps - an array of _tx/ids that must have succeeded for the current transaction to be accepted.
+ */
 function signTransaction(auth, db, expire, fuel, nonce, privateKey, tx, deps){
 
     var dbLower = db.toLowerCase();
@@ -104,7 +117,17 @@ function signTransaction(auth, db, expire, fuel, nonce, privateKey, tx, deps){
     return { cmd: stringifiedCmd, sig: sig }
 }
 
-function signQuery( privateKey, param, queryType, host, db, auth ){
+/**
+ * signQuery returns an object that can be used to sign a query.
+ * The POST method is assumed to generate the signing string.
+ *
+ * @param {string} privateKey - private key used to create the signed request
+ * @param {string} param - JSON stringified query
+ * @param {string} queryType - identifies the target endpoint (e.g., query)
+ * @param {string} db - the complete name of the ledger (e.g., test/one)
+ * @param {string} auth - auth used to submit the request
+ */
+function signQuery( privateKey, param, queryType, db, auth ){
 
     var dbLower = db.toLowerCase();
 
@@ -144,6 +167,16 @@ function signQuery( privateKey, param, queryType, host, db, auth ){
 
 }
 
+/**
+ * signRequest returns an object that can be used to sign a request 
+ * not related to queries or commands targeted for the command endpoint.
+ *
+ * @param {string} method - e.g., GET, POST or PUT
+ * @param {string} url - full URL (e.g., http://localhost:8090/fdb/delete-db)
+ * @param {string} body - JSON stringified transaction or command
+ * @param {string} privateKey - private key used to create the signed request
+ * @param {string} auth - auth used to submit the request
+ */
 function signRequest( method, url, body, privateKey, auth ){
 
   var uriParts = parseURL(url);


### PR DESCRIPTION
Changes related to FC-661:
- dropped host parameter from signQuery since it is no longer needed to generate the signing string
- updated readme: adding breaking changes section at the top, modified signQuery example to exclude host

Changes related to FC-1179:
- added missing slash to signing string
- updated readme: added example to sign request to the transact endpoint

In general, added some js doc to the primary method calls (signQuery, signRequest, signTransaction)
